### PR TITLE
L5.5 MorphToMany Compatibility

### DIFF
--- a/src/Database/Relations/MorphToMany.php
+++ b/src/Database/Relations/MorphToMany.php
@@ -161,7 +161,7 @@ class MorphToMany extends BelongsToMany
         $using = $this->using;
 
         $pivot = $using ? $using::fromRawAttributes($this->parent, $attributes, $this->table, $exists)
-                        : new MorphPivot($this->parent, $attributes, $this->table, $exists);
+                        : MorphPivot::fromAttributes($this->parent, $attributes, $this->table, $exists);
 
         $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)
               ->setMorphType($this->morphType)


### PR DESCRIPTION
MorphPivot constructor extending Eloquent\Model since L5.5 and now there is some error in develop branch:

> Type error: Argument 1 passed to Illuminate\Database\Eloquent\Model::__construct() must be of the type array, object given, called in .../vendor/october/rain/src/Database/Relations/MorphToMany.php on line 164


So i just looked for a new Laravel implementation and used code from it.